### PR TITLE
Replaced searchposts call

### DIFF
--- a/comments.js
+++ b/comments.js
@@ -39,20 +39,25 @@ async function loadTemplate(url) {
 async function discoverPost(authorHandle, options={}) {
   const currentUrl = options.renderOptions?.discoverURL || window.location.href;
   const discoverType = options.renderOptions?.discoverType || "oldest";
-  const apiUrl = `https://public.api.bsky.app/xrpc/app.bsky.feed.searchPosts?q=*&url=${encodeURIComponent(
-    currentUrl
-  )}&author=${authorHandle}&sort=${discoverType}`;
+  const apiUrl = `https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=${authorHandle}&filter=posts_no_replies`;
   console.log(apiUrl);
   try {
     const response = await fetch(apiUrl);
     const data = await response.json();
 
-    if (data.posts && data.posts.length > 0) {
-      // "oldest" isn't real, so sending sort=oldest just gives us Latest, so we take the last post.
-      const post = discoverType === "oldest" ? data.posts[data.posts.length - 1] : data.posts[0];
-      loadComments(post.uri, options);
-    } else {
-      console.log('No matching post found linking to ' + currentUrl);
+    if (data.feed)
+    {
+      let postIndex = data.feed.findIndex(element => element.post.record.facets?.[0].features?.[0].uri === encodeURIComponent);
+      let post = data.feed[postIndex].post
+      if (postIndex > -1)
+      {
+        console.log('Found the post at: ' + post.uri);
+        loadComments(post.uri, options);
+      }
+      else
+      {
+        console.log('No matching post found linking to ' + currentUrl);
+      }
     }
   } catch (err) {
     console.log('Error attempting to fetch post at ' + currentUrl);

--- a/comments.js
+++ b/comments.js
@@ -48,17 +48,18 @@ async function discoverPost(authorHandle, options={}) {
     if (data.feed)
     {
       let postIndex = -1;
-      if (discoverType == "oldest")
+      if (discoverType == "latest")
         {
-          postIndex = data.feed.findLastIndex(element => element.post.record.facets?.[0].features?.[0].uri === encodeURIComponent);
+          postIndex = data.feed.findIndex(element => element.post.record.facets?.[0].features?.[0].uri === currentUrl);
         }
-      else if (discoverType == "latest")
+      //defeault to "oldest" sorting method
+      else
         {
-          postIndex = data.feed.findIndex(element => element.post.record.facets?.[0].features?.[0].uri === encodeURIComponent);
+          postIndex = data.feed.findLastIndex(element => element.post.record.facets?.[0].features?.[0].uri === currentUrl);
         }
-      let post = data.feed[postIndex].post
       if (postIndex > -1)
       {
+        let post = data.feed[postIndex].post
         console.log('Found the post at: ' + post.uri);
         loadComments(post.uri, options);
       }
@@ -68,7 +69,7 @@ async function discoverPost(authorHandle, options={}) {
       }
     }
   } catch (err) {
-    console.log('Error attempting to fetch post at ' + currentUrl);
+    console.log('Error attempting to fetch post at ' + currentUrl + '. Error: ' + err);
   }
 }
 

--- a/comments.js
+++ b/comments.js
@@ -47,7 +47,15 @@ async function discoverPost(authorHandle, options={}) {
 
     if (data.feed)
     {
-      let postIndex = data.feed.findIndex(element => element.post.record.facets?.[0].features?.[0].uri === encodeURIComponent);
+      let postIndex = -1;
+      if (discoverType == "oldest")
+        {
+          postIndex = data.feed.findLastIndex(element => element.post.record.facets?.[0].features?.[0].uri === encodeURIComponent);
+        }
+      else if (discoverType == "latest")
+        {
+          postIndex = data.feed.findIndex(element => element.post.record.facets?.[0].features?.[0].uri === encodeURIComponent);
+        }
       let post = data.feed[postIndex].post
       if (postIndex > -1)
       {


### PR DESCRIPTION
Here's my attempt at a resolution to https://github.com/Kayinnasaki/bsky-comments/issues/9.

Based on the talk [here](https://github.com/bluesky-social/bsky-docs/issues/332) and [here](https://github.com/bluesky-social/atproto/issues/2838) it looks like BlueSky will intentionally degrade performance on the public searchPosts api when there's load issues - making it trigger 403 errors. When this happens it'll also bring up a CORS error.

To fix this instead of using the general searchPosts endpoint I've swapped over to the [getAuthorFeed](https://docs.bsky.app/docs/api/app-bsky-feed-get-author-feed) endpoint - unfortunately it doesn't have the same sorting and searching options that searchPosts has so I had to add my own check to find the post - and it doesn't support the 'top' discovery options anymore. If this change ends up being good someone better at JS than me could probably figure out a reimplementation of the Top discovery type.